### PR TITLE
Feature/move wait-for-condition methods to helper

### DIFF
--- a/dist/helpers/wait-for-condition.helper.js
+++ b/dist/helpers/wait-for-condition.helper.js
@@ -13,12 +13,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 const timeout = parseInt(_config2.default.elementsVisibilityTimeout) * 1000;
 
-const waitForVisibilityOf = exports.waitForVisibilityOf = elementName => {
-  return waitForCondition('visibilityOf', timeout)(elementName);
+const waitForVisibilityOf = exports.waitForVisibilityOf = element => {
+  return waitForCondition('visibilityOf', timeout)(element);
 };
 
-const waitForInvisibilityOf = exports.waitForInvisibilityOf = elementName => {
-  return waitForCondition('invisibilityOf', timeout)(elementName);
+const waitForInvisibilityOf = exports.waitForInvisibilityOf = element => {
+  return waitForCondition('invisibilityOf', timeout)(element);
 };
 
 const waitForCondition = exports.waitForCondition = (condition, timeout) => {

--- a/dist/helpers/wait-for-condition.helper.js
+++ b/dist/helpers/wait-for-condition.helper.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.waitForCondition = exports.waitForInvisibilityOf = exports.waitForVisibilityOf = undefined;
+
+var _config = require('./config.helper');
+
+var _config2 = _interopRequireDefault(_config);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const timeout = parseInt(_config2.default.elementsVisibilityTimeout) * 1000;
+
+const waitForVisibilityOf = exports.waitForVisibilityOf = elementName => {
+  return waitForCondition('visibilityOf', timeout)(elementName);
+};
+
+const waitForInvisibilityOf = exports.waitForInvisibilityOf = elementName => {
+  return waitForCondition('invisibilityOf', timeout)(elementName);
+};
+
+const waitForCondition = exports.waitForCondition = (condition, timeout) => {
+  return element => {
+    if (element instanceof protractor.ElementArrayFinder) {
+      return browser.wait(protractor.ExpectedConditions[condition](element.first()), timeout);
+    }
+
+    return browser.wait(protractor.ExpectedConditions[condition](element), timeout);
+  };
+};

--- a/dist/pages/base.js
+++ b/dist/pages/base.js
@@ -8,6 +8,8 @@ var _config = require('../helpers/config.helper');
 
 var _config2 = _interopRequireDefault(_config);
 
+var _waitForCondition = require('../helpers/wait-for-condition.helper');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 class Page {
@@ -160,23 +162,11 @@ class Page {
   }
 
   waitForVisibilityOf(elementName) {
-    const timeout = parseInt(_config2.default.elementsVisibilityTimeout) * 1000;
-
-    if (this[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions['visibilityOf'](this[elementName].get(0)), timeout);
-    }
-
-    return browser.wait(protractor.ExpectedConditions['visibilityOf'](this[elementName]), timeout);
+    return (0, _waitForCondition.waitForVisibilityOf)(this[elementName]);
   }
 
   waitForInvisibilityOf(elementName) {
-    const timeout = parseInt(_config2.default.elementsVisibilityTimeout) * 1000;
-
-    if (this[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions['invisibilityOf'](this[elementName].get(0)), timeout);
-    }
-
-    return browser.wait(protractor.ExpectedConditions['invisibilityOf'](this[elementName]), timeout);
+    return (0, _waitForCondition.waitForInvisibilityOf)(this[elementName]);
   }
 }
 

--- a/dist/step_definitions/elements.js
+++ b/dist/step_definitions/elements.js
@@ -18,6 +18,8 @@ var _chalk = require('chalk');
 
 var _chalk2 = _interopRequireDefault(_chalk);
 
+var _waitForCondition = require('../helpers/wait-for-condition.helper');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
@@ -27,10 +29,10 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
     const timeout = parseInt(_config2.default.elementsVisibilityTimeout) * 1000;
 
     if (this.currentPage[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions[condition](this.currentPage[elementName].get(0)), timeout);
+      return (0, _waitForCondition.waitForCondition)(condition, timeout)(this.currentPage[elementName].first());
     }
 
-    return browser.wait(protractor.ExpectedConditions[condition](this.currentPage[elementName]), timeout);
+    return (0, _waitForCondition.waitForCondition)(condition, timeout)(this.currentPage[elementName]);
   });
 
   When(/^I scroll to the "([^"]*)" element$/, function (elementName) {

--- a/functional-tests/features/content/wait_for_element_dissapear.feature
+++ b/functional-tests/features/content/wait_for_element_dissapear.feature
@@ -2,10 +2,17 @@ Feature: Element visibility
     As a kakunin user
     I want to wait for element to disappear
 
-    Scenario: Check visibility
+    Scenario: Check visibility - disappear step
         Given I visit the "main" page
         When I click the "buttonLink" element
         Then the "buttonForm" page is displayed
         When I click the "disappearBtn" element
         Then I wait for the "disappearBtn" element to disappear
 
+    Scenario: Check visibility with - wait for condition step
+        Given I visit the "main" page
+        When I click the "buttonLink" element
+        Then the "buttonForm" page is displayed
+        When I click the "disappearBtn" element
+        And I wait for "invisibilityOf" of the "disappearBtn" element
+        Then the "disappearBtn" element is not visible

--- a/src/helpers/wait-for-condition.helper.js
+++ b/src/helpers/wait-for-condition.helper.js
@@ -1,0 +1,20 @@
+import config from './config.helper';
+const timeout = parseInt(config.elementsVisibilityTimeout) * 1000;
+
+export const waitForVisibilityOf = (elementName) => {
+  return waitForCondition('visibilityOf', timeout)(elementName);
+};
+
+export const waitForInvisibilityOf = (elementName) => {
+  return waitForCondition('invisibilityOf', timeout)(elementName);
+};
+
+export const waitForCondition = (condition, timeout) => {
+  return element => {
+    if (element instanceof protractor.ElementArrayFinder) {
+      return browser.wait(protractor.ExpectedConditions[condition](element.first()), timeout);
+    }
+
+    return browser.wait(protractor.ExpectedConditions[condition](element), timeout);
+  }
+};

--- a/src/helpers/wait-for-condition.helper.js
+++ b/src/helpers/wait-for-condition.helper.js
@@ -1,12 +1,12 @@
 import config from './config.helper';
 const timeout = parseInt(config.elementsVisibilityTimeout) * 1000;
 
-export const waitForVisibilityOf = (elementName) => {
-  return waitForCondition('visibilityOf', timeout)(elementName);
+export const waitForVisibilityOf = (element) => {
+  return waitForCondition('visibilityOf', timeout)(element);
 };
 
-export const waitForInvisibilityOf = (elementName) => {
-  return waitForCondition('invisibilityOf', timeout)(elementName);
+export const waitForInvisibilityOf = (element) => {
+  return waitForCondition('invisibilityOf', timeout)(element);
 };
 
 export const waitForCondition = (condition, timeout) => {

--- a/src/pages/base.js
+++ b/src/pages/base.js
@@ -1,4 +1,5 @@
 import config from '../helpers/config.helper';
+import { waitForVisibilityOf, waitForInvisibilityOf } from '../helpers/wait-for-condition.helper';
 
 class Page {
   visit() {
@@ -152,23 +153,11 @@ class Page {
   }
 
   waitForVisibilityOf(elementName) {
-    const timeout = parseInt(config.elementsVisibilityTimeout) * 1000;
-
-    if (this[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions['visibilityOf'](this[elementName].get(0)), timeout);
-    }
-
-    return browser.wait(protractor.ExpectedConditions['visibilityOf'](this[elementName]), timeout);
+    return waitForVisibilityOf(this[elementName]);
   }
 
   waitForInvisibilityOf(elementName) {
-    const timeout = parseInt(config.elementsVisibilityTimeout) * 1000;
-
-    if (this[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions['invisibilityOf'](this[elementName].get(0)), timeout);
-    }
-
-    return browser.wait(protractor.ExpectedConditions['invisibilityOf'](this[elementName]), timeout);
+    return waitForInvisibilityOf(this[elementName]);
   }
 }
 

--- a/src/step_definitions/elements.js
+++ b/src/step_definitions/elements.js
@@ -3,17 +3,18 @@ import { matchers, regexBuilder } from '../matchers';
 import variableStore from '../helpers/variable-store.helper';
 import { comparators } from '../comparators';
 import config from '../helpers/config.helper';
-import  chalk from 'chalk';
+import chalk from 'chalk';
+import { waitForCondition } from '../helpers/wait-for-condition.helper';
 
 defineSupportCode(function ({ When, Then }) {
   When(/^I wait for "([^"]*)" of the "([^"]*)" element$/, function (condition, elementName) {
     const timeout = parseInt(config.elementsVisibilityTimeout) * 1000;
 
     if (this.currentPage[elementName] instanceof protractor.ElementArrayFinder) {
-      return browser.wait(protractor.ExpectedConditions[condition](this.currentPage[elementName].get(0)), timeout);
+      return waitForCondition(condition, timeout)(this.currentPage[elementName].first());
     }
 
-    return browser.wait(protractor.ExpectedConditions[condition](this.currentPage[elementName]), timeout);
+    return waitForCondition(condition, timeout)(this.currentPage[elementName]);
   });
 
   When(/^I scroll to the "([^"]*)" element$/, function (elementName) {


### PR DESCRIPTION
- Add `wait-for-condition.helper.js`
- Move methods from `/page/base.js` to `/helpers/wait-for-condition.helper.js`
- Improvement: use method from `wait-for-condition.helper.js` in `wait for condition step`
- Added functional test covering `invisibilityOf`